### PR TITLE
I18n some work for multilingual support

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -27,3 +27,8 @@
 # Footer
 - id: poweredBy
   translation: 'This page was built with <a href="https://gohugo.io/">Hugo {{ . }}</a> using the <a href="https://github.com/basil/antora-default-ui-hugo-theme">Hugo port</a> of the <a href="https://gitlab.com/antora/antora-ui-default">Antora default UI</a>. The source code for this UI is licensed under the terms of the <a href="https://www.mozilla.org/en-US/MPL/2.0/">Mozilla Public License, Version 2.0</a> (MPL-2.0).'
+
+
+# Taxo
+- id: categories
+  translation: catégories

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -19,14 +19,14 @@
 
 # 404 page
 - id: pageNotFoundLink
-  translation: 'Cette page n&rsquo;existe pas. Elle se trouve probablement ailleurs sur le site. Vous pouvez soit retourner à la  <a href="{{ .RelPermalink }}">page d&rsquo;acceuil</a> ou bien suivre les liens de navigation à gauche.'
+  translation: 'Cette page n&rsquo;existe pas. Elle se trouve probablement ailleurs sur le site. Vous pouvez retourner à la  <a href="{{ .RelPermalink }}">page d&rsquo;acceuil</a> ou bien suivre les liens de navigation à gauche.'
 - id: pageNotFoundAction
   translation: 'Si vous êtes arrivé ici en cliquant sur un lien, Veuillez avertir le propriétaire du site que le lien est brisé. Si vous avez tapé le lien manuellement veuillez vérifiez que vous l&rsquo;avez saisi correctement.'
 
 
 # Footer
 - id: poweredBy
-  translation: 'Cette page a été construit avec <a href="https://gohugo.io/">Hugo {{ . }}</a> et le <a href="https://github.com/basil/antora-default-ui-hugo-theme">port Hugo</a> de <a href="https://gitlab.com/antora/antora-ui-default">Antora default UI</a>. Ce code est publié sous les termes de <a href="https://www.mozilla.org/en-US/MPL/2.0/">Mozilla Public License, Version 2.0</a> (MPL-2.0).'
+  translation: 'Cette page a été construite avec <a href="https://gohugo.io/">Hugo {{ . }}</a> et le <a href="https://github.com/basil/antora-default-ui-hugo-theme">port Hugo</a> de <a href="https://gitlab.com/antora/antora-ui-default">Antora default UI</a>. Ce code est publié sous les termes de <a href="https://www.mozilla.org/en-US/MPL/2.0/">Mozilla Public License, Version 2.0</a> (MPL-2.0).'
 
 
 # Taxo

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -1,0 +1,34 @@
+# Content
+- id: contents
+  translation: "Sur cette page..."
+- id: continueReading
+  translation: "Poursuivre la lecture &ldquo;{{ . }}&rdquo; &hellip;"
+- id: dateFormat
+  translation: "January 2, 2006"
+- id: editThisPage
+  translation: "Editer cette page"
+- id: in
+  translation: "en"
+- id: lastModified
+  translation: "(Modifié le {{ . }})"
+- id: postedOnDate
+  translation: "Enrégistré le {{ . }}"
+- id: taggedWith
+  translation: "Marqué par"
+
+
+# 404 page
+- id: pageNotFoundLink
+  translation: 'Cette page n&rsquo;existe pas. Elle se trouve probablement ailleurs sur le site. Vous pouvez soit retourner à la  <a href="{{ .RelPermalink }}">page d&rsquo;acceuil</a> ou bien suivre les liens de navigation à gauche.'
+- id: pageNotFoundAction
+  translation: 'Si vous êtes arrivé ici en cliquant sur un lien, Veuillez avertir le propriétaire du site que le lien est brisé. Si vous avez tapé le lien manuellement veuillez vérifiez que vous l&rsquo;avez saisi correctement.'
+
+
+# Footer
+- id: poweredBy
+  translation: 'Cette page a été construit avec <a href="https://gohugo.io/">Hugo {{ . }}</a> et le <a href="https://github.com/basil/antora-default-ui-hugo-theme">port Hugo</a> de <a href="https://gitlab.com/antora/antora-ui-default">Antora default UI</a>. Ce code est publié sous les termes de <a href="https://www.mozilla.org/en-US/MPL/2.0/">Mozilla Public License, Version 2.0</a> (MPL-2.0).'
+
+
+# Taxo
+- id: categories
+  translation: catégories

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html{{ with .Site.LanguageCode }} lang="{{ . }}"{{ end }}>
+<html{{ with .Language.Lang }} lang="{{ . }}"{{ end }}>
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/partials/header-content.html
+++ b/layouts/partials/header-content.html
@@ -16,12 +16,12 @@
               <a class="navbar-link" href="#" title="{{ .Title | markdownify }}">{{ .Name }}</a>
               <div class="navbar-dropdown">
                 {{ range .Children }}
-                    <a class="navbar-item" href="{{ .URL }}" title="{{ .Title | markdownify }}">{{ .Name }}</a>
+                    <a class="navbar-item" href="{{ .URL | absLangURL }}" title="{{ .Title | markdownify }}">{{ .Name }}</a>
                 {{ end }}
               </div>
             </div>
           {{ else }}
-            <a class="navbar-item" href="{{ .URL }}" title="{{ .Title | markdownify }}">{{ .Name }}</a>
+            <a class="navbar-item" href="{{ .URL | absLangURL }}" title="{{ .Title | markdownify }}">{{ .Name }}</a>
           {{ end }}
         {{ end }}
       </div>

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,3 +1,3 @@
-<aside class="toc sidebar" data-title="{{ i18n "Contents" }}" data-levels="2">
+<aside class="toc sidebar" data-title="{{ i18n "contents" }}" data-levels="2">
   <div class="toc-menu"></div>
 </aside>


### PR DESCRIPTION
Hi.   Awesome antora hugo theme.  All the submitted pulls are tested on [Coastsystems](https://www.coastsystems.net), where I have used your template and added my blog stuff too.  (This was just in the last few days so I will send more pull requests if you wish)

Actually over the past 3 years I have gone through several types of asciidoctor/antora hugo combos.  

1.  A bulma blog site with antora doc styleheet for content only.
2. A bare hugo site styled with a single asciidoctor stylesheet (ok I cheated by adding a font and a few other things...) But an interesting challenge/concept.  (But I got tired of the plain look)
3. Adding back bulma (for cards, tags and other formatting) and reverting back to a lot of Antora css
4. Ditching Bulma and using your amazingly awesome port!

As you can see here [Coastsystems](https://www.coastsystems.net), I have made your template mostly multilingual, but there is still a fair amount of work (date formats; more absLanURL's; i18n, for example)   As I use the site I can fix and contribute back if you wish.   Right now I have the language selector on the navbar, but it would be really great to get it into and <antora-like) module selector.

I also have the docs section on my site in an [Antora site](https://dyu.coastsystems.net) as well.   Just an fyi i have used hugo modules for the 'docs', and 'blog'.   The 'docs', are pulled from the Antora docs repository as well.  So the docs on those two previous links are synced.

I did try to install the antora-hugo-default-ui as a hugo module but it refused to download.  I will get back to that.

Cheers!
